### PR TITLE
Update README.md for adding column with default

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Finally we’ll backport the default value for existing data in batches. This sh
 
 ```ruby
 class BackportPublishedDefaultOnPosts < ActiveRecord::Migration[5.0]
-  def change
+  def up
     Post.select(:id).find_in_batches.with_index do |batch, index|
       puts "Processing batch #{index}\r"
       Post.where(id: batch).update_all(published: true)


### PR DESCRIPTION
I think this operation only makes sense in one direction. Rolling it back probably works (no errors) but does not achieve the opposite of this operation. Making it an `up` block might make this more clear.

Happy to be told I'm wrong if there's something I've misunderstood.