### PR TITLE
ENV cutoff date to disable checks for old migrations

### DIFF
--- a/lib/zero_downtime_migrations/migration.rb
+++ b/lib/zero_downtime_migrations/migration.rb
@@ -29,7 +29,7 @@ module ZeroDowntimeMigrations
       Migration.data = false
       Migration.ddl = false
       Migration.index = false
-      Migration.safe ||= reverse_migration? || rollup_migration?
+      Migration.safe ||= reverse_migration? || rollup_migration? || old_migration?
 
       super.tap do
         validate(:ddl_migration)
@@ -89,6 +89,12 @@ module ZeroDowntimeMigrations
 
     def rollup_migration?
       self.class.name == "RollupMigrations"
+    end
+
+    def old_migration?
+      version = ENV['ZERO_DOWNTIME_MIGRATIONS_LAST_UNSAFE_VERSION']
+
+      version && self.version <= version.to_i
     end
 
     def safety_assured

--- a/spec/zero_downtime_migrations/migration_spec.rb
+++ b/spec/zero_downtime_migrations/migration_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe ZeroDowntimeMigrations::Migration do
+  let(:error) { ZeroDowntimeMigrations::UnsafeMigrationError }
+
+  context "with a migration that adds a column and index" do
+    let(:migration) do
+      Class.new(ActiveRecord::Migration[5.0]) do
+        def change
+          add_column :users, :active, :boolean
+          add_index :users, :active
+        end
+      end
+    end
+
+    it "raises an unsafe migration error" do
+      expect { migration.migrate(:up) }.to raise_error(error)
+    end
+
+    context "with ZERO_DOWNTIME_MIGRATIONS_LAST_UNSAFE_VERSION set" do
+      around(:each) do |example|
+        ENV['ZERO_DOWNTIME_MIGRATIONS_LAST_UNSAFE_VERSION'] = '20130101000000'
+
+        example.run
+
+        ENV.delete('ZERO_DOWNTIME_MIGRATIONS_LAST_UNSAFE_VERSION')
+      end
+
+      it "raises an unsafe migration error when version > ZERO_DOWNTIME_MIGRATIONS_LAST_UNSAFE_VERSION" do
+        expect_any_instance_of(migration).to receive(:version).at_least(:once).and_return(20130101000001)
+        expect { migration.migrate(:up) }.to raise_error(error)
+      end
+
+      it "doesn't raise an unsafe migration error when version == ZERO_DOWNTIME_MIGRATIONS_LAST_UNSAFE_VERSION" do
+        expect_any_instance_of(migration).to receive(:version).at_least(:once).and_return(20130101000000)
+        expect { migration.migrate(:up) }.to_not raise_error(error)
+      end
+
+      it "doesn't raise an unsafe migration error when version < ZERO_DOWNTIME_MIGRATIONS_LAST_UNSAFE_VERSION" do
+        expect_any_instance_of(migration).to receive(:version).at_least(:once).and_return(20121231235959)
+        expect { migration.migrate(:up) }.to_not raise_error(error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When introducing this gem in an old project with many migrations, it's not feasible to tag dozens of migrations with `safety_assured`.

This PR introduces the ability to disable safety checks for old migrations (which presumably have already been run on the production db) via the ENV variable `ZERO_DOWNTIME_MIGRATIONS_LAST_UNSAFE_VERSION`.