### PR TITLE
Suggest the reversible version of change_column_default

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Then we’ll set the new column default in a separate migration. Note that this 
 ```ruby
 class SetPublishedDefaultOnPosts < ActiveRecord::Migration
   def change
-    change_column_default :posts, :published, true
+    change_column_default :posts, :published, from: nil, to: true
   end
 end
 ```

--- a/lib/zero_downtime_migrations/validation/add_column.rb
+++ b/lib/zero_downtime_migrations/validation/add_column.rb
@@ -31,7 +31,7 @@ module ZeroDowntimeMigrations
 
             class AddDefault#{column_title}To#{table_title} < ActiveRecord::Migration
               def change
-                change_column_default :#{table}, :#{column}, #{column_default}
+                change_column_default :#{table}, :#{column}, from: nil, to: #{column_default}
               end
             end
 


### PR DESCRIPTION
The validation for safely adding a new column with a default uses `change_column_default` suggests an irreversible migration with `change_column_default` (see the note at the bottom of [section 3.4 of the migrations guide](https://edgeguides.rubyonrails.org/active_record_migrations.html#changing-columns)). 

Specifying a `from` and `to` to allow us to rollback much more easily.  