### PR TITLE
Warn when droping table in a foregin key constrain

### DIFF
--- a/lib/zero_downtime_migrations.rb
+++ b/lib/zero_downtime_migrations.rb
@@ -11,6 +11,7 @@ require_relative "zero_downtime_migrations/validation/add_index"
 require_relative "zero_downtime_migrations/validation/ddl_migration"
 require_relative "zero_downtime_migrations/validation/find_each"
 require_relative "zero_downtime_migrations/validation/mixed_migration"
+require_relative "zero_downtime_migrations/validation/remove_column"
 
 ActiveRecord::Migration.send(:prepend, ZeroDowntimeMigrations::Migration)
 ActiveRecord::Schema.send(:prepend, ZeroDowntimeMigrations::Migration)

--- a/lib/zero_downtime_migrations/validation/remove_column.rb
+++ b/lib/zero_downtime_migrations/validation/remove_column.rb
@@ -1,0 +1,53 @@
+module ZeroDowntimeMigrations
+  class Validation
+    class RemoveColumn < Validation
+      def validate!
+        error!(message) if postgresql? && exists_in_constraint?
+      end
+
+      private
+
+      def message
+        <<-MESSAGE.strip_heredoc
+          It looks like #{column} is in a foreign_key constraint.  Be aware that removing a foreign_key takes an `AccessExclusiveLock`
+          on both tables (i.e. also on the one being refered to).  This will lock your queries to both tables.
+
+          If you're 100% positive that this migration is already safe, then wrap the
+          call to `remove_column` in a `safety_assured` block.
+        MESSAGE
+      end
+
+      def postgresql?
+        connection.class == ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+      end
+
+      def column
+        args[1]
+      end
+
+      def table
+        args[0]
+      end
+
+      def exists_in_constraint?
+        connection.select_value(
+          <<~SQL
+            SELECT 1 AS one
+            FROM pg_constraint c
+              JOIN LATERAL UNNEST(c.conkey) WITH ORDINALITY AS u(attnum, attposition) ON TRUE
+              JOIN pg_class tbl ON tbl.oid = c.conrelid
+              JOIN pg_namespace sch ON sch.oid = tbl.relnamespace
+              JOIN pg_attribute col ON (col.attrelid = tbl.oid AND col.attnum = u.attnum)
+              WHERE c.contype = 'f' AND col.attname = '#{column}' AND tbl.relname = '#{table}'
+                AND sch.nspname = '#{connection.current_schema}'
+              LIMIT 1
+          SQL
+        ) == 1
+      end
+
+      def connection
+        ActiveRecord::Base.connection
+      end
+    end
+  end
+end

--- a/spec/zero_downtime_migrations/validation/remove_column_spec.rb
+++ b/spec/zero_downtime_migrations/validation/remove_column_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe ZeroDowntimeMigrations::Validation::RemoveColumn do
+  let(:error) { ZeroDowntimeMigrations::UnsafeMigrationError }
+
+  context "when the column droped is in a foreign_key constraint" do
+    before do
+      Class.new(ActiveRecord::Migration[5.0]) do
+        def change
+          create_table(:orders) do |t|
+            t.references :user, foreign_key: true
+          end
+        end
+      end.migrate(:up)
+    end
+
+    let(:migration) do
+      Class.new(ActiveRecord::Migration[5.0]) do
+        def change
+          remove_column(:orders, :user_id)
+        end
+      end
+    end
+
+    it "raises an unsafe migration error" do
+      expect { migration.migrate(:up) }.to raise_error(error)
+    end
+  end
+
+  context "when the column droped is not in a foreign_key constraint" do
+    let(:migration) do
+      Class.new(ActiveRecord::Migration[5.0]) do
+        def change
+          create_table(:orders) do |t|
+            t.references :user
+          end
+          remove_column(:orders, :user_id)
+        end
+      end
+    end
+
+    it "raises an unsafe migration error" do
+      expect { migration.migrate(:up) }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
Adding a warning when a removed column is in a foreign key as this locks both tables.

This adds a query, not sure how you feel about that but otherwise the message would appear for all `remove_column` calls which seems a bit excessive.