### PR TITLE
Rename safety_assured to disable_safety_checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,23 +248,23 @@ end
 
 ## Disabling "zero downtime migration" enforcements
 
-We can disable any of these "zero downtime migration" enforcements by wrapping them in a `safety_assured` block.
+We can disable any of these "zero downtime migration" enforcements by wrapping them in a `disable_safety_checks!` block.
 
 ```ruby
 class AddPublishedToPosts < ActiveRecord::Migration
   def change
-    safety_assured do
+    disable_safety_checks! do
       add_column :posts, :published, :boolean, default: true
     end
   end
 end
 ```
 
-We can also mark an entire migration as safe by using the `safety_assured` helper method.
+We can also mark an entire migration as safe by using the `disable_safety_checks!` helper method.
 
 ```ruby
 class AddPublishedToPosts < ActiveRecord::Migration
-  safety_assured
+  disable_safety_checks!
 
   def change
     add_column :posts, :published, :boolean

--- a/README.md
+++ b/README.md
@@ -273,10 +273,10 @@ class AddPublishedToPosts < ActiveRecord::Migration
 end
 ```
 
-Enforcements can be globally disabled by setting `ENV["SAFETY_ASSURED"]` when running migrations.
+Enforcements can be globally disabled by setting `ENV["DISABLE_SAFETY_CHECKS"]` when running migrations.
 
 ```bash
-SAFETY_ASSURED=1 bundle exec rake db:migrate --trace
+DISABLE_SAFETY_CHECKS=1 bundle exec rake db:migrate --trace
 ```
 
 These enforcements are **automatically disabled by default for the following scenarios**:

--- a/lib/zero_downtime_migrations/dsl.rb
+++ b/lib/zero_downtime_migrations/dsl.rb
@@ -23,11 +23,22 @@ module ZeroDowntimeMigrations
     end
 
     def safe?
-      !!@safe || ENV["DISABLE_SAFETY_CHECKS"].presence
+      !!@safe || begin
+        if ENV["SAFETY_ASSURED"].presence
+          warn "DEPRECATED: setting SAFETY_ASSURED is deprecated. Please use DISABLE_SAFETY_CHECKS instead."
+        end
+
+        ENV["DISABLE_SAFETY_CHECKS"].presence || ENV["SAFETY_ASSURED"].presence
+      end
     end
 
     def disable_safety_checks!
       Migration.safe = true
+    end
+
+    def safety_assured
+      warn "DEPRECATED: calling safety_assured is deprecated. Please use disable_safety_checks! instead."
+      disable_safety_checks!
     end
 
     def unsafe?

--- a/lib/zero_downtime_migrations/dsl.rb
+++ b/lib/zero_downtime_migrations/dsl.rb
@@ -23,7 +23,7 @@ module ZeroDowntimeMigrations
     end
 
     def safe?
-      !!@safe || ENV["SAFETY_ASSURED"].presence
+      !!@safe || ENV["DISABLE_SAFETY_CHECKS"].presence
     end
 
     def disable_safety_checks!

--- a/lib/zero_downtime_migrations/dsl.rb
+++ b/lib/zero_downtime_migrations/dsl.rb
@@ -26,7 +26,7 @@ module ZeroDowntimeMigrations
       !!@safe || ENV["SAFETY_ASSURED"].presence
     end
 
-    def safety_assured
+    def disable_safety_checks!
       Migration.safe = true
     end
 

--- a/lib/zero_downtime_migrations/migration.rb
+++ b/lib/zero_downtime_migrations/migration.rb
@@ -95,7 +95,7 @@ module ZeroDowntimeMigrations
       self.class.name == "RollupMigrations"
     end
 
-    def safety_assured
+    def disable_safety_checks!
       safe = Migration.safe
       Migration.safe = true
       yield

--- a/lib/zero_downtime_migrations/migration.rb
+++ b/lib/zero_downtime_migrations/migration.rb
@@ -103,6 +103,11 @@ module ZeroDowntimeMigrations
       Migration.safe = safe
     end
 
+    def safety_assured(&block)
+      warn "DEPRECATED: calling safety_assured is deprecated. Please use disable_safety_checks! instead."
+      disable_safety_checks!(&block)
+    end
+
     def validate(type, *args)
       Validation.validate!(type, *args)
     rescue UndefinedValidationError

--- a/lib/zero_downtime_migrations/validation/add_column.rb
+++ b/lib/zero_downtime_migrations/validation/add_column.rb
@@ -60,11 +60,11 @@ module ZeroDowntimeMigrations
             end
 
           If you're 100% positive that this migration is already safe, then wrap the
-          call to `add_column` in a `safety_assured` block.
+          call to `add_column` in a `disable_safety_checks!` block.
 
             class Add#{column_title}To#{table_title} < ActiveRecord::Migration
               def change
-                safety_assured { add_column :#{table}, :#{column}, :#{column_type}, default: #{column_default} }
+                disable_safety_checks! { add_column :#{table}, :#{column}, :#{column_type}, default: #{column_default} }
               end
             end
         MESSAGE

--- a/lib/zero_downtime_migrations/validation/add_index.rb
+++ b/lib/zero_downtime_migrations/validation/add_index.rb
@@ -30,11 +30,11 @@ module ZeroDowntimeMigrations
             end
 
           If you're 100% positive that this migration is already safe, then wrap the
-          call to `add_index` in a `safety_assured` block.
+          call to `add_index` in a `disable_safety_checks!` block.
 
             class Index#{table_title}On#{column_title} < ActiveRecord::Migration
               def change
-                safety_assured { add_index :#{table}, #{column.inspect} }
+                disable_safety_checks! { add_index :#{table}, #{column.inspect} }
               end
             end
         MESSAGE

--- a/lib/zero_downtime_migrations/validation/ddl_migration.rb
+++ b/lib/zero_downtime_migrations/validation/ddl_migration.rb
@@ -20,11 +20,11 @@ module ZeroDowntimeMigrations
           the DDL transaction enabled just in case they need to be rolled back.
 
           If you're 100% positive that this migration is already safe, then simply
-          add a call to `safety_assured` to your migration.
+          add a call to `disable_safety_checks!` to your migration.
 
             class #{migration_name} < ActiveRecord::Migration
               disable_ddl_transaction!
-              safety_assured
+              disable_safety_checks!
 
               def change
                 # ...

--- a/lib/zero_downtime_migrations/validation/find_each.rb
+++ b/lib/zero_downtime_migrations/validation/find_each.rb
@@ -17,11 +17,11 @@ module ZeroDowntimeMigrations
           records into memory all at the same time!
 
           If you're 100% positive that this migration is already safe, then wrap the
-          call to `each` in a `safety_assured` block.
+          call to `each` in a `disable_safety_checks!` block.
 
             class #{migration_name} < ActiveRecord::Migration
               def up
-                safety_assured do
+                disable_safety_checks! do
                   # use ActiveRecord::Relation.each in this block
                 end
               end

--- a/lib/zero_downtime_migrations/validation/mixed_migration.rb
+++ b/lib/zero_downtime_migrations/validation/mixed_migration.rb
@@ -26,10 +26,10 @@ module ZeroDowntimeMigrations
             be created without the DDL transaction enabled to avoid table locking.
 
           If you're 100% positive that this migration is already safe, then simply
-          add a call to `safety_assured` to your migration.
+          add a call to `disable_safety_checks!` to your migration.
 
             class #{migration_name} < ActiveRecord::Migration
-              safety_assured
+              disable_safety_checks!
 
               def change
                 # ...

--- a/spec/internal/db/migrate/20161012223253_safe_add_column_with_default.rb
+++ b/spec/internal/db/migrate/20161012223253_safe_add_column_with_default.rb
@@ -1,5 +1,5 @@
 class SafeAddColumnWithDefault < ActiveRecord::Migration[5.0]
   def change
-    safety_assured { add_column :posts, :published, :boolean, default: false }
+    disable_safety_checks! { add_column :posts, :published, :boolean, default: false }
   end
 end

--- a/spec/internal/db/migrate/20161012223254_safe_add_index.rb
+++ b/spec/internal/db/migrate/20161012223254_safe_add_index.rb
@@ -1,5 +1,5 @@
 class SafeAddIndex < ActiveRecord::Migration[5.0]
   def change
-    safety_assured { add_index :posts, :published }
+    disable_safety_checks! { add_index :posts, :published }
   end
 end

--- a/spec/internal/db/migrate/20161012223255_safe_add_index_with_env.rb
+++ b/spec/internal/db/migrate/20161012223255_safe_add_index_with_env.rb
@@ -1,7 +1,7 @@
 class SafeAddIndexWithEnv < ActiveRecord::Migration[5.0]
   def change
-    ENV["SAFETY_ASSURED"] = "1"
+    ENV["DISABLE_SAFETY_CHECKS"] = "1"
     add_index :users, :created_at
-    ENV.delete("SAFETY_ASSURED")
+    ENV.delete("DISABLE_SAFETY_CHECKS")
   end
 end

--- a/spec/internal/db/migrate/20161012223256_safe_add_index_with_dsl.rb
+++ b/spec/internal/db/migrate/20161012223256_safe_add_index_with_dsl.rb
@@ -1,5 +1,5 @@
 class SafeAddIndexWithDsl < ActiveRecord::Migration[5.0]
-  safety_assured
+  disable_safety_checks!
 
   def change
     add_index :posts, :created_at

--- a/spec/zero_downtime_migrations/deprecated_spec.rb
+++ b/spec/zero_downtime_migrations/deprecated_spec.rb
@@ -1,0 +1,65 @@
+RSpec.describe "deprecations" do
+  let(:error) { ZeroDowntimeMigrations::UnsafeMigrationError }
+
+  describe "safety_assured" do
+    context "when used inline with a block" do
+      let(:migration) do
+        Class.new(ActiveRecord::Migration[5.0]) do
+          def change
+            safety_assured do
+              add_index :users, :updated_at
+            end
+          end
+        end
+      end
+
+      it "does not raise an unsafe migration error" do
+        expect { migration.migrate(:up) }.to_not raise_error(error)
+      end
+
+      it "issues a deprecation warning" do
+        expect { migration.migrate(:up) }.to output(/deprecated/).to_stderr
+      end
+    end
+
+    context "when used for the whole migration" do
+      let(:migration) do
+        Class.new(ActiveRecord::Migration[5.0]) do
+          safety_assured
+
+          def change
+            add_index :users, :updated_at
+          end
+        end
+      end
+
+      it "does not raise an unsafe migration error" do
+        expect { migration.migrate(:up) }.to_not raise_error(error)
+      end
+
+      it "issues a deprecation warning" do
+        expect { migration.migrate(:up) }.to output(/deprecated/).to_stderr
+      end
+    end
+
+    context "when set via SAFETY_ASSURED environment variable" do
+      let(:migration) do
+        Class.new(ActiveRecord::Migration[5.0]) do
+          def change
+            ENV["SAFETY_ASSURED"] = "1"
+            add_index :users, :updated_at
+            ENV.delete("SAFETY_ASSURED")
+          end
+        end
+      end
+
+      it "does not raise an unsafe migration error" do
+        expect { migration.migrate(:up) }.to_not raise_error(error)
+      end
+
+      it "issues a deprecation warning" do
+        expect { migration.migrate(:up) }.to output(/deprecated/).to_stderr
+      end
+    end
+  end
+end

--- a/spec/zero_downtime_migrations/validation/find_each_spec.rb
+++ b/spec/zero_downtime_migrations/validation/find_each_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe ZeroDowntimeMigrations::Validation::FindEach do
     end
   end
 
-  context "with data migrations using each within safety_assured" do
+  context "with data migrations using each within disable_safety_checks!" do
     let(:migration) do
       Class.new(ActiveRecord::Migration[5.0]) do
         def change
-          safety_assured do
+          disable_safety_checks! do
             User.all.each
           end
         end


### PR DESCRIPTION
First things first, this is an awesome gem, super valuable. Thank you for creating it 👍 

# What?

This PR proposes renaming the:

* `safety_assured` DSL methods to `disable_safety_checks!` and the 
* `SAFETY_ASSURED` environment variable  to `DISABLE_SAFETY_CHECKS` 

The 3rd commit reintroduces the old names but with deprecation warnings printed to the stderr. Happy to drop this if you like, but I felt it might be worth keeping them in for the next version to ease the migration path, then they could be dropped in the version after that.

# Why?

Today I came across several real-world cases of developers assuming in good faith that the `safety_assured` call meant "make my migration safe", whereas in fact it means "disable the safety checks, I know what I am doing". People were assuming that they needed to use this block to opt-in.

In light of this, and the gem still having an alpha version, I am suggesting this change so there is no doubt.