### PR TITLE
Fix ArgumentError in Ruby 3

### DIFF
--- a/lib/zero_downtime_migrations/migration.rb
+++ b/lib/zero_downtime_migrations/migration.rb
@@ -82,6 +82,8 @@ module ZeroDowntimeMigrations
       validate(method, *args)
       super
     end
+    ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
+
 
     def old_migration?
       version && version <= ENV["ZERO_DOWNTIME_MIGRATIONS_LAST_UNSAFE_VERSION"].to_i


### PR DESCRIPTION
```
ArgumentError: wrong number of arguments (given 2, expected 1)
/Users/yosi/.rvm/gems/ruby-3.0.2/gems/activerecord-6.1.4/lib/active_record/migration.rb:929:in `block in method_missing'
/Users/yosi/.rvm/gems/ruby-3.0.2/gems/activerecord-6.1.4/lib/active_record/migration.rb:897:in `block in say_with_time'
/Users/yosi/.rvm/gems/ruby-3.0.2/gems/activerecord-6.1.4/lib/active_record/migration.rb:897:in `say_with_time'
/Users/yosi/.rvm/gems/ruby-3.0.2/gems/activerecord-6.1.4/lib/active_record/migration.rb:918:in `method_missing'
/Users/yosi/.rvm/gems/ruby-3.0.2/gems/zero_downtime_migrations-0.0.7/lib/zero_downtime_migrations/migration.rb:83:in `method_missing'
/Users/yosi/.rvm/gems/ruby-3.0.2/gems/zero_downtime_migrations-0.0.7/lib/zero_downtime_migrations/migration.rb:83:in `method_missing'
/Users/yosi/code/rails-appdb/schema.rb:27:in `block in <main>'
```